### PR TITLE
Make pathfinding methods use Position

### DIFF
--- a/src/main/java/com/group4/app/controller/WorldController.java
+++ b/src/main/java/com/group4/app/controller/WorldController.java
@@ -39,7 +39,7 @@ public class WorldController {
     }
 
     public Set<Position> getLegalMoves(){
-        return PathfindingHelper.getSurrounding(model.getTile(new Position(getPlayerPosition().getX(), getPlayerPosition().getY(), model.getPlayerFloor())), 5);
+        return PathfindingHelper.getSurrounding(new Position(getPlayerPosition().getX(), getPlayerPosition().getY(), model.getPlayerFloor()), 5, model);
     }
 
     public Set<Position> getHighlightedPositions(){
@@ -66,7 +66,7 @@ public class WorldController {
         }
         
         //FIXME dont get straight from internal model classes
-        List<Position> positions = PathfindingHelper.getShortestPath(model.getTile(new Position(playerX,playerY,model.getPlayerFloor())), model.getTile(targePosition));
+        List<Position> positions = PathfindingHelper.getShortestPath(new Position(playerX,playerY,model.getPlayerFloor()), targePosition, model);
 
         highlightedPositions = new HashSet<Position>(positions);
         
@@ -115,7 +115,7 @@ public class WorldController {
 
         Position targetPosition  = pos;
 
-        List<Position> positions = PathfindingHelper.getShortestPath(model.getTile(new Position(playerX,playerY,model.getPlayerFloor())), model.getTile(targetPosition));
+        List<Position> positions = PathfindingHelper.getShortestPath(new Position(playerX, playerY, model.getPlayerFloor()), targetPosition, model);
 
         if(!movementTimerFlag && !hoverFlag){
             if(getLegalMoves().contains(targetPosition)){

--- a/src/main/java/com/group4/app/model/Model.java
+++ b/src/main/java/com/group4/app/model/Model.java
@@ -228,7 +228,7 @@ public class Model implements IWorldContainer {
     }
 
     public Set<Position> getSurrounding(Position pos, int steps) {
-        return PathfindingHelper.getSurrounding(getTile(pos), steps);
+        return PathfindingHelper.getSurrounding(pos, steps, this);
     }
 
     public void giveExperience(int xp) {
@@ -259,7 +259,7 @@ public class Model implements IWorldContainer {
     }
 
     public List<Position> getPathFromTo(Position startPos, Position targetPos){
-        return PathfindingHelper.getShortestPath(getTile(startPos), getTile(targetPos));
+        return PathfindingHelper.getShortestPath(startPos, targetPos, this);
     }
 
     public int getPlayerHealth() {

--- a/src/main/java/com/group4/app/model/PathfindingHelper.java
+++ b/src/main/java/com/group4/app/model/PathfindingHelper.java
@@ -1,10 +1,9 @@
 package com.group4.app.model;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
-import java.util.Stack;
 
+import com.group4.app.model.dungeon.ITileContainer;
 import com.group4.app.model.dungeon.Tile;
 
 import java.util.List;
@@ -33,7 +32,9 @@ public class PathfindingHelper {
      * @param steps
      * @return Set of Points with all legal positions
      */
-    public static Set<Position> getSurrounding(Tile tile, int steps) {
+    public static Set<Position> getSurrounding(Position pos, int steps, ITileContainer tc) {
+
+    Tile tile = tc.getTile(pos);
     Set<Tile> visited = new HashSet<>();
     Queue<Entry> queue = new LinkedList<>();
     Set<Position> positions = new HashSet<>();
@@ -126,8 +127,11 @@ public class PathfindingHelper {
      * @param goal
      * @return List representing the shortest path between two tiles
      */
-    public static List<Position> getShortestPath(Tile start, Tile goal) {
-        AStarEntry finalEntry = aStarSearch(start, goal);
+    public static List<Position> getShortestPath(Position start, Position goal, ITileContainer tc) {
+        Tile startTile = tc.getTile(start);
+        Tile goalTile = tc.getTile(goal);
+
+        AStarEntry finalEntry = aStarSearch(startTile, goalTile);
         return extractPath(finalEntry);  
     }
 
@@ -137,8 +141,10 @@ public class PathfindingHelper {
      * @param goal
      * @return List of tiles representing the shortest path between start and tile next to goal
      */
-    public static List<Position> getPathNextTo(Tile start, Tile goal) {
-        AStarEntry finalEntry = aStarSearch(start, goal);
+    public static List<Position> getPathNextTo(Position start, Position goal, ITileContainer tc) {
+        Tile startTile = tc.getTile(start);
+        Tile goalTile = tc.getTile(goal);
+        AStarEntry finalEntry = aStarSearch(startTile, goalTile);
         List<Position> path = extractPath(finalEntry);
         path.remove(path.size()-1);
         return path;
@@ -194,15 +200,18 @@ public class PathfindingHelper {
 
 
     /**
-     * @param start
-     * @param goal
+     * @param startTile
+     * @param goalTile
      * @return The shortest path from start to goal.
      * If the goal cannot be reached, the path to the closest tile is returned
      */
-    public static List<Position> pathToClosest(Tile start, Tile goal) {
+    public static List<Position> pathToClosest(Position start, Position goal, ITileContainer tc) {
+        Tile startTile = tc.getTile(start);
+        Tile goalTile = tc.getTile(goal);
+
         PriorityQueue<AStarEntry> pq = new PriorityQueue<>();
         Set<Tile> visited = new HashSet<>();
-        AStarEntry startEntry = new AStarEntry(start, null, null, 0, guessCost(start, goal));
+        AStarEntry startEntry = new AStarEntry(startTile, null, null, 0, guessCost(startTile, goalTile));
         AStarEntry closest = startEntry;
         pq.add(startEntry);
         
@@ -217,10 +226,10 @@ public class PathfindingHelper {
                 closest = entry;
             for (Edge edge : entry.getOutgoingEdges()) {
                 double costToHere = entry.getCostToHere() + edge.getWeight();
-                double guessedCost = guessCost(edge.getEnd(), goal);
+                double guessedCost = guessCost(edge.getEnd(), goalTile);
                 AStarEntry newEntry = new AStarEntry(edge.getEnd(), edge, entry, costToHere, guessedCost);
-                if (edge.getEnd() == goal) {
-                    if (goal.isEmpty()) {
+                if (edge.getEnd() == goalTile) {
+                    if (goalTile.isEmpty()) {
                         closest = newEntry;
                     }
                     break;

--- a/src/main/java/com/group4/app/model/actions/PlayerAttackAction.java
+++ b/src/main/java/com/group4/app/model/actions/PlayerAttackAction.java
@@ -36,7 +36,7 @@ public class PlayerAttackAction extends Action<ICanAttack, IAttackable> {
     }
 
     public Set<IAttackable> getTargetable() {
-        Set<Position> positions = PathfindingHelper.getSurrounding(Model.getInstance().getTile(this.getActionTaker().getPos()), 1);
+        Set<Position> positions = PathfindingHelper.getSurrounding(this.getActionTaker().getPos(), 1, Model.getInstance());
         positions.remove(getActionTaker().getPos());
         Set<IAttackable> attackables = new HashSet<IAttackable>();
         for (Position position : positions) {

--- a/src/main/java/com/group4/app/model/actions/PlayerMoveAction.java
+++ b/src/main/java/com/group4/app/model/actions/PlayerMoveAction.java
@@ -36,7 +36,7 @@ public class PlayerMoveAction extends Action<IPositionable, Position>{
     }
 
     public Set<Position> getTargetable() {
-        return PathfindingHelper.getSurrounding(Model.getInstance().getTile(getActionTaker().getPos()), 5);
+        return PathfindingHelper.getSurrounding(getActionTaker().getPos(), 5, Model.getInstance());
     }
 
     public Set<Position> getTargetablePositions() {

--- a/src/test/java/com/group4/app/testmodel/TestPathFinderHelper.java
+++ b/src/test/java/com/group4/app/testmodel/TestPathFinderHelper.java
@@ -43,8 +43,8 @@ public class TestPathFinderHelper {
         correctPositions.add(new Position(1, 0, worldId));
         correctPositions.add(new Position(3, 0, worldId));
         correctPositions.add(new Position(2, 0, worldId));
-        Tile startingTile = model.getTile(new Position(startX, startY, worldId));
-        Set<Position> legalPositions = PathfindingHelper.getSurrounding(startingTile, 1);
+        Position startingPos = new Position(startX, startY, worldId);
+        Set<Position> legalPositions = PathfindingHelper.getSurrounding(startingPos, 1, model);
         assertTrue(correctPositions.containsAll(legalPositions) && legalPositions.size() == correctPositions.size());
     }
 
@@ -57,9 +57,9 @@ public class TestPathFinderHelper {
         model.add(world);
         model.setCurrentWorld(worldId);
         initFlatWorld(5, world);
-        Tile start = model.getTile(new Position(0, 0, worldId));
-        Tile goal = model.getTile(new Position(2, 0, worldId));
-        List<Position> path = PathfindingHelper.getShortestPath(start, goal);
+        Position start = new Position(0, 0, worldId);
+        Position goal = new Position(2, 0, worldId);
+        List<Position> path = PathfindingHelper.getShortestPath(start, goal, world);
 
         LinkedList<Position> correctPath = new LinkedList<>();
         correctPath.addFirst(new Position(2, 0, worldId));
@@ -75,9 +75,9 @@ public class TestPathFinderHelper {
         String worldId = world.getId();
         model.setCurrentWorld(worldId);
         initFlatWorld(5, world);
-        Tile start = model.getTile(new Position(0, 0, worldId));
-        Tile goal = model.getTile(new Position(4, 0, worldId));
-        List<Position> path = PathfindingHelper.getPathNextTo(start, goal);
+        Position start = new Position(0, 0, worldId);
+        Position goal = new Position(4, 0, worldId);
+        List<Position> path = PathfindingHelper.getPathNextTo(start, goal, model);
         LinkedList<Position> correctPath = new LinkedList<>();
         
         correctPath.addFirst(new Position(3, 0, worldId));
@@ -95,9 +95,9 @@ public class TestPathFinderHelper {
         initFlatWorld(5, world);
         model.setCurrentWorld(world.getId());
         String worldId = model.getCurrentWorldId();
-        Tile start = model.getTile(new Position(0, 0, worldId));
-        Tile goal = model.getTile(new Position(4, 0, worldId));
-        List<Position> path = PathfindingHelper.pathToClosest(start, goal);
+        Position start = new Position(0, 0, worldId);
+        Position goal = new Position(4, 0, worldId);
+        List<Position> path = PathfindingHelper.pathToClosest(start, goal, model);
         List<Position> correctPositions = new ArrayList<>();
         correctPositions.add(new Position(1, 0, worldId));
         correctPositions.add(new Position(2, 0, worldId));
@@ -114,11 +114,11 @@ public class TestPathFinderHelper {
         initFlatWorld(5, world);
         model.setCurrentWorld(world.getId());
         String worldId = model.getCurrentWorldId();
-        Tile start = model.getTile(new Position(0, 0, worldId));
-        Tile goal = model.getTile(new Position(4, 0, worldId));
+        Position start = new Position(0, 0, worldId);
+        Position goal = new Position(4, 0, worldId);
         Tile obstacle = model.getTile(new Position(2, 0, worldId));
         obstacle.add(EnemyFactory.createZombie(obstacle.getPos()));
-        List<Position> path = PathfindingHelper.pathToClosest(start, goal);
+        List<Position> path = PathfindingHelper.pathToClosest(start, goal, model);
         Position finalPosition = path.get(path.size() - 1);
         assertEquals(new Position(1, 0, worldId), finalPosition);
     }


### PR DESCRIPTION
This will implement a Dependency injection pattern to allow clients to use all of PathfindingHelper's public methods without depending on the Tile class.